### PR TITLE
allow Slugify to take callable pretranslate

### DIFF
--- a/slugify/main.py
+++ b/slugify/main.py
@@ -69,7 +69,7 @@ class Slugify(object):
         elif pretranslate is None:
             pretranslate = lambda text: text
 
-        else:
+        elif not hasattr(pretranslate, '__call__'):
             error_message = u"Keyword argument 'pretranslate' must be dict, None or callable. Not {0.__class__.__name__}".format(pretranslate)
             raise ValueError(error_message)
 

--- a/slugify/tests.py
+++ b/slugify/tests.py
@@ -90,6 +90,13 @@ class PretranslateTestCase(unittest.TestCase):
         self.assertEqual(slugify_emoji(u'(c)'), u'copyright')
         self.assertEqual(slugify_emoji(u'©'), u'copyright')
 
+    def test_pretranslate_lambda(self):
+        slugify_reverse = Slugify(pretranslate=lambda value: value[::-1])
+        self.assertEqual(
+            slugify_reverse('slug'),
+            'guls'
+        )
+
     def test_wrong_argument_type(self):
         self.assertRaises(ValueError, lambda: Slugify(pretranslate={1, 2}))
 


### PR DESCRIPTION
`Slugify::set_pretranslate` should accept a dictionary, a callable, or None, but as currently implemented, it only accepts a dict or None. This PR allows `set_translate` to take a callable as well. All tests passing.
