### PR TITLE
Fix to_lower with unicode text

### DIFF
--- a/slugify/main.py
+++ b/slugify/main.py
@@ -150,10 +150,9 @@ class Slugify(object):
             text = text.decode('utf8', 'ignore')
 
         if kwargs.get('to_lower', self.to_lower):
-            text = text.lower()
             text = self._pretranslate(text)
             text = self._translate(text)
-
+            text = text.lower()
         else:
             text_parts = self.upper_to_upper_letters_re.split(text)
 

--- a/slugify/tests.py
+++ b/slugify/tests.py
@@ -74,6 +74,9 @@ class ToLowerTestCase(unittest.TestCase):
     def test_to_lower_with_capitalize(self):
         self.assertEqual(slugify('Test TO lower', to_lower=True, capitalize=True), 'Test-to-lower')
 
+    def test_to_lower_with_unicode(self):
+        self.assertEqual(slugify('自転車', to_lower=True), 'zi-zhuan-che')
+
 
 class UpperTestCase(unittest.TestCase):
     def test_full_upper(self):


### PR DESCRIPTION
I noticed that when trying to do something like:

``` python
slugify('自転車', to_lower=True)
```

I got `Zi-Zhuan-Che` instead of the expected `zi-zhuan-che`. Effectively I introduced a test which failed, implemented a fix, and all tests kept passing.
