### PR TITLE
Fix tests to run in Python 2.6 and add py26 to tox.ini

### DIFF
--- a/slugify/tests.py
+++ b/slugify/tests.py
@@ -134,7 +134,7 @@ class PretranslateTestCase(unittest.TestCase):
         self.assertEqual(slugify_reverse('slug'), 'guls')
 
     def test_wrong_argument_type(self):
-        self.assertRaises(ValueError, lambda: Slugify(pretranslate={1, 2}))
+        self.assertRaises(ValueError, lambda: Slugify(pretranslate=set([1, 2])))
 
 
 class SanitizeTestCase(unittest.TestCase):
@@ -298,7 +298,7 @@ class DeprecationTestCase(unittest.TestCase):
 
             slugify = get_slugify()
             self.assertEqual(slugify('This % is a test ---'), 'This-is-a-test')
-            self.assertIn("'slugify.get_slugify' is deprecated", str(warning[-1].message))
+            self.assertTrue("'slugify.get_slugify' is deprecated" in str(warning[-1].message))
 
 
 if __name__ == '__main__':

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34
+envlist = py26,py27,py33,py34
 
 [testenv]
 commands=


### PR DESCRIPTION
Some minor changes to tests.py to allow Python 2.6 compatibility.