### PR TITLE
Fix for import on python 2.7.7 (windows)

### DIFF
--- a/slugify/__init__.py
+++ b/slugify/__init__.py
@@ -1,6 +1,6 @@
 
-from slugify.main import Slugify, UniqueSlugify
-from slugify.alt_translates import *
+from .main import Slugify, UniqueSlugify
+from .alt_translates import *
 
 
 slugify = Slugify()


### PR DESCRIPTION
Error with awesome-slugify 1.6.4:

python -c "from slugify import UniqueSlugify"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "myvirtualenv\lib\site-packages\slugify__init__.py", line 2, in <module>
    from slugify.main import Slugify, UniqueSlugify
ImportError: No module named main
