### PR TITLE
Add unslug() to UniqueSlugify() to reverse map slugs

### DIFF
--- a/slugify/tests.py
+++ b/slugify/tests.py
@@ -263,7 +263,7 @@ class UniqueTestCase(unittest.TestCase):
         slugify = UniqueSlugify(uids=['This-is-my-test', 'This-is-another-test'])
         self.assertEqual(slugify('This % is a test ---'), 'This-is-a-test')
         self.assertEqual(slugify('This % is my test ---'), 'This-is-my-test-1')
-        self.assertTrue(isinstance(slugify.uids, set))
+        self.assertTrue(isinstance(slugify.uids, dict))
 
         slugify = UniqueSlugify(uids=set(["let-me-not", "to-the-marriage", "of-true-minds"]))
         self.assertEqual(slugify("of-true-minds"), "of-true-minds-1")
@@ -289,6 +289,13 @@ class UniqueTestCase(unittest.TestCase):
         self.assertEqual(slugify('te occidere possunt'), 'te-occidere-possunt-1')
         self.assertEqual(slugify('boo'), 'boo-1')
         self.assertEqual(slugify('boo'), 'boo-2')
+
+    def test_unslug(self):
+        slugify = UniqueSlugify()
+        self.assertEqual(slugify('This % is a test ---'), 'This-is-a-test')
+        self.assertEqual(slugify.unslug('This-is-a-test'), 'This % is a test ---')
+        self.assertEqual(slugify('This ! is a test ---'), 'This-is-a-test-1')
+        self.assertEqual(slugify.unslug('This-is-a-test-1'), 'This ! is a test ---')
 
 
 class DeprecationTestCase(unittest.TestCase):


### PR DESCRIPTION
Since `UniqueSlugify` already maintains a set of used `uids`, it's a small step from there to map these back to the original text used to create them.

For example, if the username `John Smith` is slugifyed into `john-smith` and used as the URL fragment `example.org/user/john-smith`, the handler can go from the slug `john-smith` back to the original name `John Smith` easily.

@dimka665 -- I've added test cases for this scenario. The existing tests aren't breaking either. Would you consider this merge request?
