### PR TITLE
Add Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ python:
   - '2.7'
   - '3.3'
   - '3.4'
+  - '3.5'
+  - 'pypy'
 
 install:
   - python setup.py install

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
     ],
     keywords='slugify slug transliteration russian german unicode translation flexible',
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,pypy
+envlist = py27,py33,py34,py35,pypy
 
 [testenv]
 commands=


### PR DESCRIPTION
Tests pass on Python 3.5 (the current stable Python release), so it
should be officially supported. This change adds Python 3.5 to automated
testing configurations and `setup.py` language classifiers.

Additionally, ensure that `pypy` tests run on travis.