### PR TITLE
Update minimum unidecode version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'regex',
-        'Unidecode>=0.04.14,<0.05',
+        'Unidecode>=0.04.14,<1.1',
     ],
 
     license='GNU GPLv3',


### PR DESCRIPTION
Unidecode has moved to semantic versioning. I don't believe there are any major changes that awesome-slugify requires.

Unidecode release change:

```
2018-01-05	unidecode 1.0.22
	* Move to semantic version numbering, no longer following version
	  numbers from the original Perl module. This fixes an issue with
	  setuptools (>= 8) and others expecting major.minor.patch format.
	  (https://github.com/avian2/unidecode/issues/13)
	* Add transliterations for currency signs U+20B0 through U+20BF
	  (thanks to Mike Swanson)
	* Surround transliterations of vulgar fractions with spaces to avoid
	  incorrect combinations with adjacent numerals
	  (thanks to Jeffrey Gerard)
```